### PR TITLE
Improved Patterns

### DIFF
--- a/src/main/java/com/todoist/markup/MarkupParser.java
+++ b/src/main/java/com/todoist/markup/MarkupParser.java
@@ -94,8 +94,8 @@ public class MarkupParser {
         Matcher matcher = Patterns.BOLD.matcher(string);
 
         while (matcher.find()) {
-            String text = matcher.group(1);
-            markupEntries.add(new MarkupEntry(MarkupType.BOLD, matcher.start(), matcher.end(), text));
+            String text = matcher.group(2);
+            markupEntries.add(new MarkupEntry(MarkupType.BOLD, matcher.start(1), matcher.end(1), text));
         }
     }
 
@@ -103,8 +103,8 @@ public class MarkupParser {
         Matcher matcher = Patterns.ITALIC.matcher(string);
 
         while (matcher.find()) {
-            String text = matcher.group(1);
-            markupEntries.add(new MarkupEntry(MarkupType.ITALIC, matcher.start(), matcher.end(), text));
+            String text = matcher.group(2);
+            markupEntries.add(new MarkupEntry(MarkupType.ITALIC, matcher.start(1), matcher.end(1), text));
         }
     }
 

--- a/src/main/java/com/todoist/markup/Patterns.java
+++ b/src/main/java/com/todoist/markup/Patterns.java
@@ -5,9 +5,9 @@ import java.util.regex.Pattern;
 class Patterns {
     public static final Pattern HEADER = Pattern.compile("^\\*\\s+");
     // Bold text is wrapped with __ or !! or **
-    public static final Pattern BOLD = Pattern.compile("(?<=^|[\\s!?,;>:\\(\\)])(?:\\*\\*|__|!!)(.*?)(?:\\*\\*|__|!!)(?=$|[\\s!?,;><:\\(\\)])");
+    public static final Pattern BOLD = Pattern.compile("(?:^|[\\s!?,;>:\\(\\)]+)((?:\\*\\*|__|!!)(.*?)(?:\\*\\*|__|!!))(?:$|[\\s!?,;><:\\(\\)]+)", Pattern.MULTILINE);
     // Italic text is wrapped with _ or *
-    public static final Pattern ITALIC = Pattern.compile("(?<=^|[\\s!?,;>:\\(\\)])(?:\\*|_)(.*?)(?:\\*|_)($|[\\s!?,;><:\\(\\)])");
+    public static final Pattern ITALIC = Pattern.compile("(?:^|[\\s!?,;>:\\(\\)]+)((?:\\*|_)(.*?)(?:\\*|_))(?:$|[\\s!?,;><:\\(\\)]+)", Pattern.MULTILINE);
     // Inline code is wrapped with `
     public static final Pattern INLINE_CODE = Pattern.compile("`([^`]+)`");
     // Code block is wrapped with ```

--- a/src/main/java/com/todoist/markup/Patterns.java
+++ b/src/main/java/com/todoist/markup/Patterns.java
@@ -5,11 +5,11 @@ import java.util.regex.Pattern;
 class Patterns {
     public static final Pattern HEADER = Pattern.compile("^\\*\\s+");
     // Bold text is wrapped with __ or !! or **
-    public static final Pattern BOLD = Pattern.compile("(?:__|!!|\\*\\*)\\s*((?!(?:__|!!|\\*\\*)).+?)\\s*(?:__|!!|\\*\\*)");
+    public static final Pattern BOLD = Pattern.compile("(?<=^|[\\s!?,;>:\\(\\)])(?:\\*\\*|__|!!)(.*?)(?:\\*\\*|__|!!)(?=$|[\\s!?,;><:\\(\\)])");
     // Italic text is wrapped with _ or *
-    public static final Pattern ITALIC = Pattern.compile("[_\\*]\\s*((?![_\\*]).+?)\\s*[_\\*]");
+    public static final Pattern ITALIC = Pattern.compile("(?<=^|[\\s!?,;>:\\(\\)])(?:\\*|_)(.*?)(?:\\*|_)($|[\\s!?,;><:\\(\\)])");
     // Inline code is wrapped with `
-    public static final Pattern INLINE_CODE = Pattern.compile("`\\s*((?!`).+?)\\s*`");
+    public static final Pattern INLINE_CODE = Pattern.compile("`([^`]+)`");
     // Code block is wrapped with ```
     public static final Pattern CODE_BLOCK = Pattern.compile("(?:```)\\s*((?!(?:```)).+?)\\s*(?:```)", Pattern.DOTALL);
     public static final Pattern LINK = Pattern.compile("((?:[a-zA-Z]+)://[^\\s]+)(?:\\s+\\(([^)]+)\\))?");


### PR DESCRIPTION
This PR makes `bold`, `italic` and `inline_code` patterns almost same as web.

Almost because one group had to be added to capture replacement position.
